### PR TITLE
Adiciona arquivo .gitignore ao repositório

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Arquivos de ambiente virtual
+venv/
+venv/*.*
+venv*/
+venv*/*.*
+
+# Arquivos de cache e logs
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.log
+logs/
+
+# Arquivos de configuração local
+instance/
+.env
+
+# Arquivos específicos do sistema operacional
+.DS_Store
+Thumbs.db
+
+# Arquivos de banco de dados
+*.db
+migrations/
+migrations/*.*
+migrations*/
+migrations*/*.*


### PR DESCRIPTION
Um arquivo .gitignore ao repositório para ajudar a manter o controle de versão mais limpo e eficiente. Um .gitignore bem configurado pode garantir que arquivos e pastas desnecessários não sejam incluídos no repositório, o que pode melhorar a velocidade de clone, reduzir o uso de espaço em disco e promover boas práticas de segurança.

